### PR TITLE
Add __str__ representation. Fix code formatting. 

### DIFF
--- a/dicio/dicio.py
+++ b/dicio/dicio.py
@@ -31,6 +31,11 @@ class Word(object):
     def __repr__(self):
         return self.word
 
+    def __str__(self):
+        if self.meaning:
+            return self.word + ': ' + self.meaning
+        return self.word
+
     def load(self):
         found = Dicio().search(self.word)
         self.meaning = found.meaning
@@ -71,7 +76,10 @@ class Dicio(object):
         """
         Return meaning.
         """
-        return Utils.remove_spaces(Utils.remove_tags(Utils.text_between(page, TAG_MEANING[0], TAG_MEANING[1], True)))
+        return Utils.remove_spaces(Utils.remove_tags(
+            Utils.text_between(page, TAG_MEANING[0],
+                               TAG_MEANING[1],
+                               True)))
 
     def synonyms(self, page):
         """
@@ -79,12 +87,18 @@ class Dicio(object):
         """
         synonyms = []
         if page.find(TAG_SYNONYMS[0]) > -1:
-            synonyms_html = Utils.text_between(page, TAG_SYNONYMS[0], TAG_SYNONYMS[1], True)
+            synonyms_html = Utils.text_between(
+                page, TAG_SYNONYMS[0], TAG_SYNONYMS[1], True)
             while synonyms_html.find(TAG_SYNONYMS_DELIMITER[0]) > -1:
-                synonym = Utils.text_between(synonyms_html, TAG_SYNONYMS_DELIMITER[0], TAG_SYNONYMS_DELIMITER[1], True)
+                synonym = Utils.text_between(synonyms_html,
+                                             TAG_SYNONYMS_DELIMITER[
+                                                 0], TAG_SYNONYMS_DELIMITER[1],
+                                             True)
                 synonyms.append(Word(Utils.remove_spaces(synonym)))
-                synonyms_html = synonyms_html.replace(TAG_SYNONYMS_DELIMITER[0], "", 1)
-                synonyms_html = synonyms_html.replace(TAG_SYNONYMS_DELIMITER[1], "", 1)
+                synonyms_html = synonyms_html.replace(
+                    TAG_SYNONYMS_DELIMITER[0], "", 1)
+                synonyms_html = synonyms_html.replace(
+                    TAG_SYNONYMS_DELIMITER[1], "", 1)
         return synonyms
 
     def extra(self, page):
@@ -94,12 +108,15 @@ class Dicio(object):
         dic_extra = {}
         try:
             if page.find(TAG_EXTRA[0]) > -1:
-                extra_html = Utils.text_between(page, TAG_EXTRA[0], TAG_EXTRA[1], True)
-                extra_rows = Utils.split_html_tag(Utils.remove_spaces(extra_html), TAG_EXTRA_SEP)
+                extra_html = Utils.text_between(
+                    page, TAG_EXTRA[0], TAG_EXTRA[1], True)
+                extra_rows = Utils.split_html_tag(
+                    Utils.remove_spaces(extra_html), TAG_EXTRA_SEP)
                 for row in extra_rows:
                     _row = Utils.remove_tags(row)
                     key, value = _row.split(":")
-                    dic_extra[Utils.remove_spaces(key)] = Utils.remove_spaces(value)
+                    dic_extra[Utils.remove_spaces(
+                        key)] = Utils.remove_spaces(value)
         except:
             pass
         return dic_extra

--- a/dicio/utils.py
+++ b/dicio/utils.py
@@ -38,7 +38,7 @@ class Utils(object):
         return str
 
     @staticmethod
-    def text_between(str, before, after, force_html = False):
+    def text_between(str, before, after, force_html=False):
         """
         Return text between before and after.
         Use force_html when before and after were html tags.
@@ -63,7 +63,8 @@ class Utils(object):
     @staticmethod
     def remove_spaces(str):
         """
-        Return a new string without double space, tabs, carriage return or line feed.
+        Return a new string without double space, tabs, carriage return
+        or line feed.
 
         >>> remove_spaces("Something  else")
         'Something else'
@@ -124,14 +125,15 @@ class Utils(object):
         """
         TEMPLATE = "<{0} />"
         templates = ["<{0}></{0}>",
-                   "<{0}></ {0}>",
-                   "<{0} ></{0}>",
-                   "<{0} ></ {0}>",
-                   "<{0}>",
-                   "<{0}/>",
-                   "<{0} >"]
+                     "<{0}></ {0}>",
+                     "<{0} ></{0}>",
+                     "<{0} ></ {0}>",
+                     "<{0}>",
+                     "<{0}/>",
+                     "<{0} >"]
 
         new_str = str
         for template in templates:
-            new_str = new_str.replace(template.format(tag), TEMPLATE.format(tag))
+            new_str = new_str.replace(
+                template.format(tag), TEMPLATE.format(tag))
         return list(filter(None, new_str.split(TEMPLATE.format(tag))))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='felipemfpontes@gmail.com',
     packages=['dicio', 'tests'],
     test_suite='tests',
-    url='https//github.com/felipemfp/dicio',
+    url='https://github.com/felipemfp/dicio',
     license='MIT License',
     description='Unofficial Python API for Dicio.',
     long_description='Unofficial Python API for Dicio. \


### PR DESCRIPTION
I add ``__str__`` representation for return meaning.
eg: 

```python
>>> dicio = Dicio()
>>> w = dicio.search('doce')
>>> print(w)
doce: adj. Que tem um sabor como do açúcar e do mel. Que não é amargo, 
nem azedo, nem salgado. [..]
```

and fix code representation, formatting with pep8 patterns:
dicio.py pep8 log:
``` 
dicio/dicio.py:20:1: E122 continuation line missing indentation or outdented
dicio/dicio.py:23:1: E122 continuation line missing indentation or outdented
dicio/dicio.py:23:19: E701 multiple statements on one line (colon)
dicio/dicio.py:24:66: E701 multiple statements on one line (colon)
dicio/dicio.py:31:23: E701 multiple statements on one line (colon)
dicio/dicio.py:34:22: E701 multiple statements on one line (colon)
dicio/dicio.py:35:24: E701 multiple statements on one line (colon)
dicio/dicio.py:39:19: E701 multiple statements on one line (colon)
dicio/dicio.py:46:1: E122 continuation line missing indentation or outdented
dicio/dicio.py:46:20: E701 multiple statements on one line (colon)
dicio/dicio.py:51:27: E701 multiple statements on one line (colon)
dicio/dicio.py:55:33: E701 multiple statements on one line (colon)
dicio/dicio.py:59:12: E701 multiple statements on one line (colon)
dicio/dicio.py:61:15: E701 multiple statements on one line (colon)
dicio/dicio.py:65:42: E701 multiple statements on one line (colon)
dicio/dicio.py:75:28: E701 multiple statements on one line (colon)
dicio/dicio.py:79:80: E501 line too long (117 > 79 characters)
dicio/dicio.py:81:29: E701 multiple statements on one line (colon)
dicio/dicio.py:86:43: E701 multiple statements on one line (colon)
dicio/dicio.py:87:80: E501 line too long (92 > 79 characters)
dicio/dicio.py:88:69: E701 multiple statements on one line (colon)
dicio/dicio.py:89:80: E501 line too long (119 > 79 characters)
dicio/dicio.py:91:80: E501 line too long (87 > 79 characters)
dicio/dicio.py:92:80: E501 line too long (87 > 79 characters)
dicio/dicio.py:95:26: E701 multiple statements on one line (colon)
dicio/dicio.py:100:12: E701 multiple statements on one line (colon)
dicio/dicio.py:101:44: E701 multiple statements on one line (colon)
dicio/dicio.py:102:80: E501 line too long (87 > 79 characters)
dicio/dicio.py:103:80: E501 line too long (97 > 79 characters)
dicio/dicio.py:104:38: E701 multiple statements on one line (colon)
dicio/dicio.py:107:80: E501 line too long (84 > 79 characters)
dicio/dicio.py:108:15: E701 multiple statements on one line (colon)
dicio/dicio.py:111:1: E901 TokenError: EOF in multi-line statement
```

utils.py pep8 log:
```
utils.py:41:52: E251 unexpected spaces around keyword / parameter equals
utils.py:41:54: E251 unexpected spaces around keyword / parameter equals
utils.py:66:80: E501 line too long (85 > 79 characters)
utils.py:127:20: E128 continuation line under-indented for visual indent
utils.py:128:20: E128 continuation line under-indented for visual indent
utils.py:129:20: E128 continuation line under-indented for visual indent
utils.py:130:20: E128 continuation line under-indented for visual indent
utils.py:131:20: E128 continuation line under-indented for visual indent
utils.py:132:20: E128 continuation line under-indented for visual indent
utils.py:136:80: E501 line too long (81 > 79 characters)
```